### PR TITLE
add "attach" functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,20 @@
 								, "default" : false
 							}
 						}
+					},
+					"attach": {
+						"properties": {
+							"request" : {
+								"type": "string"
+								, "description": "Attaches to a swf which is launched manually"
+								, "default" : "attach"
+							}
+							, "receiveAdapterOutput" : {
+								"type" : "bool"
+								, "description" : "redirect adapter log to debug console"
+								, "default" : false
+							}
+						}
 					}
 				},
 

--- a/src/FDBAdapter.hx
+++ b/src/FDBAdapter.hx
@@ -1,6 +1,7 @@
 package;
 
 import fdbAdapter.commands.Launch;
+import fdbAdapter.commands.Attach;
 import fdbAdapter.commands.*;
 import vshaxeDebug.Context;
 import vshaxeDebug.IDebugger;
@@ -66,6 +67,16 @@ class FDBAdapter extends adapter.DebugSession {
             redirectTraceToDebugConsole(context);
         }
         debugger.queueCommand(new Launch(context, response, customArgs));
+        debugger.queueCommand(new CacheSourcePaths(context));
+    }
+
+    override function attachRequest(response:AttachResponse, args:AttachRequestArguments) {
+        var customArgs:FDBAttachRequestArguments = cast args;
+        if ((customArgs.receiveAdapterOutput != null) && 
+            (customArgs.receiveAdapterOutput)) {
+            redirectTraceToDebugConsole(context);
+        }
+        debugger.queueCommand(new Attach(context, response, customArgs));
         debugger.queueCommand(new CacheSourcePaths(context));
     }
 

--- a/src/fdbAdapter/commands/Attach.hx
+++ b/src/fdbAdapter/commands/Attach.hx
@@ -1,0 +1,24 @@
+package fdbAdapter.commands;
+
+import vshaxeDebug.Context;
+import protocol.debug.Types.LaunchResponse;
+import protocol.debug.Types.OutputEventCategory;
+
+
+typedef FDBAttachRequestArguments =
+{
+   > protocol.debug.Types.LaunchRequestArguments,
+   @:optional var receiveAdapterOutput:Bool;
+}
+
+class Attach extends Launch {
+    
+    public function new(context:Context, response:LaunchResponse, args:FDBAttachRequestArguments) {
+        super(context, response, cast args);
+    }
+
+    override function execute() {
+        debugger.send('run');
+        context.sendToOutput('waiting..', OutputEventCategory.stdout);
+    }
+}

--- a/src/vshaxeDebug/CLIAdapter.hx
+++ b/src/vshaxeDebug/CLIAdapter.hx
@@ -11,6 +11,7 @@ typedef CLIAdapterConfig = {
     var prompt:String;
     var onPromptGot:Array<String> -> Void;
     var allOutputReceiver:String -> Bool;
+
 }
 
 class CLIAdapter implements IDebugger {
@@ -26,11 +27,15 @@ class CLIAdapter implements IDebugger {
     var queueHead:DebuggerCommand;
     var queueTail:DebuggerCommand;
 
+    var linebreakSign: String;
+
+
     public function new(config:CLIAdapterConfig) {
         this.config = config;
         this.onPromptGot = config.onPromptGot;
         this.allOutputReceiver = config.allOutputReceiver;
         buffer = new Buffer(0);
+        this.linebreakSign = js.Node.process.platform == "win32" ? "\r\n" : "\n";
     }
 
     public function start() {
@@ -98,7 +103,7 @@ class CLIAdapter implements IDebugger {
         var promptLength = config.prompt.length;
         if (string.substr(-promptLength) == config.prompt) {
             var fdbOutput = string.substring(0, string.length - promptLength );
-            var lines = fdbOutput.split("\r\n");
+            var lines = fdbOutput.split(linebreakSign);
             lines.pop();
             buffer = new Buffer(0);
             if (currentCommand != null) {


### PR DESCRIPTION
Add "attach" as a launch configuration request type.

By that adl (Adobe Air Debug Launcher) is also kind of supported. You can just start adl manually and let the debugger attach to it.